### PR TITLE
Support changing directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo ${KUBE_CONFIG_DATA} | base64 -d > kubeconfig
-export KUBECONFIG=kubeconfig
+export KUBECONFIG="${PWD}/kubeconfig"
 
 echo "running entrypoint command(s)"
 


### PR DESCRIPTION
This patch adds support for changing directory before running helm - without it, helm complains that it cannot find the kubeconfig file because it expects it to be in the current directory.